### PR TITLE
urlencode for python 2 and python 3

### DIFF
--- a/BinanceAPI.py
+++ b/BinanceAPI.py
@@ -1,7 +1,14 @@
 import time
 import hashlib
 import requests
-from urllib import urlencode
+
+try:
+    from urllib import urlencode
+except ImportError:
+    from urllib.parse import urlencode
+
+#from urllib.parse import urlencode
+#from urllib import urlencode
 #https://github.com/purboox/BinanceAPI
 
 class BinanceAPI:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3
-
+ADD config.py /
+ADD BinanceAPI.py /
 ADD trader.py /
-
 RUN pip install requests
-
 CMD [ "python", "./trader.py" ]


### PR DESCRIPTION
Fixed **ImportError** in Python3 "_cannot import name ‘urlencode’ in Python3_" and made the code compatible for both Python 2 and Python 3. Also, Dockerfile was updated.