### PR TITLE
chore: log spread on screen log

### DIFF
--- a/app/Trading.py
+++ b/app/Trading.py
@@ -333,7 +333,6 @@ class Trading():
         if self.option.prints and self.order_id == 0:
             spreadPerc = (lastAsk/lastBid - 1) * 100.0
             print ('price:%.8f buyp:%.8f sellp:%.8f-bid:%.8f ask:%.8f spread:%.2f' % (lastPrice, buyPrice, profitableSellingPrice, lastBid, lastAsk, spreadPerc))
-            print ('price:%.8f buyp:%.8f sellp:%.8f-bid:%.8f ask:%.8f' % (lastPrice, buyPrice, profitableSellingPrice, lastBid, lastAsk))
         
         # analyze = threading.Thread(target=analyze, args=(symbol,))
         # analyze.start()

--- a/app/Trading.py
+++ b/app/Trading.py
@@ -331,6 +331,8 @@ class Trading():
     
         # Screen log
         if self.option.prints and self.order_id == 0:
+            spreadPerc = (lastAsk/lastBid - 1) * 100.0
+            print ('price:%.8f buyp:%.8f sellp:%.8f-bid:%.8f ask:%.8f spread:%.2f' % (lastPrice, buyPrice, profitableSellingPrice, lastBid, lastAsk, spreadPerc))
             print ('price:%.8f buyp:%.8f sellp:%.8f-bid:%.8f ask:%.8f' % (lastPrice, buyPrice, profitableSellingPrice, lastBid, lastAsk))
         
         # analyze = threading.Thread(target=analyze, args=(symbol,))


### PR DESCRIPTION
This PR is to log the spread between bid and ask values. I find it useful to get some visual feedback.

This is an example of the output:

    price:0.00193290 buyp:0.00193370 sellp:0.00195874-bid:0.00193360 ask:0.00194580 spread:0.63