### PR TITLE
Fix #156

### DIFF
--- a/app/Trading.py
+++ b/app/Trading.py
@@ -266,7 +266,7 @@ class Trading():
         if self.order_id > 0:
             exit(1)
 
-    def check_partial_order(self, symbol, orderId, price):
+    def check_partial_order(self, symbol, orderId, sell_price):
         time.sleep(self.WAIT_TIME_BUY_SELL)
         partial_status = "hold"
         quantity = 0


### PR DESCRIPTION
Fix https://github.com/yasinkuyu/binance-trader/issues/156:  Users get a traceback that looks like this:
```Buy order created id:3519495, q:750.00000000, p:0.00026565
Buy order partially filled... Wait 1 more second...
Order still partially filled...
Traceback (most recent call last):
  File "trader.py", line 46, in <module>
    t.run()
  File "./app/Trading.py", line 494, in run
    self.action(symbol)
  File "./app/Trading.py", line 378, in action
    self.sell(symbol, quantity, self.order_id, profitableSellingPrice, lastPrice)
  File "./app/Trading.py", line 110, in sell
    quantity = self.check_partial_order(symbol, orderId, sell_price)
  File "./app/Trading.py", line 281, in check_partial_order
    if self.min_notional > quantity * sell_price:
NameError: global name 'sell_price' is not defined```