### PR TITLE
BASE url upgrade to BASE_URL_V3 to support sign method and new features

### DIFF
--- a/app/BinanceAPI.py
+++ b/app/BinanceAPI.py
@@ -45,7 +45,7 @@ class BinanceAPI:
         return self._get_no_sign(path, params)
 
     def get_account(self):
-        path = "%s/account" % self.BASE_URL
+        path = "%s/account" % self.BASE_URL_V3
         return self._get(path, {})
 
     def get_products(self):
@@ -56,7 +56,7 @@ class BinanceAPI:
         return requests.get(path, timeout=30, verify=True).json()
 
     def get_open_orders(self, market, limit = 100):
-        path = "%s/openOrders" % self.BASE_URL
+        path = "%s/openOrders" % self.BASE_URL_V3
         params = {"symbol": market}
         return self._get(path, params)
     
@@ -66,27 +66,27 @@ class BinanceAPI:
         return self._get(path, params)
 
     def buy_limit(self, market, quantity, rate):
-        path = "%s/order" % self.BASE_URL
+        path = "%s/order" % self.BASE_URL_V3
         params = self._order(market, quantity, "BUY", rate)
         return self._post(path, params)
 
     def sell_limit(self, market, quantity, rate):
-        path = "%s/order" % self.BASE_URL
+        path = "%s/order" % self.BASE_URL_V3
         params = self._order(market, quantity, "SELL", rate)
         return self._post(path, params)
 
     def buy_market(self, market, quantity):
-        path = "%s/order" % self.BASE_URL
+        path = "%s/order" % self.BASE_URL_V3
         params = self._order(market, quantity, "BUY")
         return self._post(path, params)
 
     def sell_market(self, market, quantity):
-        path = "%s/order" % self.BASE_URL
+        path = "%s/order" % self.BASE_URL_V3
         params = self._order(market, quantity, "SELL")
         return self._post(path, params)
 
     def query_order(self, market, orderId):
-        path = "%s/order" % self.BASE_URL
+        path = "%s/order" % self.BASE_URL_V3
         params = {"symbol": market, "orderId": orderId}
         return self._get(path, params)
 


### PR DESCRIPTION
To use myTrades endpoint _sign method is changed to support API v3. After that, sell-buy options are also needed to upgrade to v3.