### PR TITLE
Fix cancel function logic error causing orders in non-cancellable states to be canceled

### DIFF
--- a/app/Trading.py
+++ b/app/Trading.py
@@ -410,7 +410,7 @@ class Trading():
                 self.order_data = None
             return True
 
-        if check_order['status'] == 'NEW' or check_order['status'] != 'CANCELLED':
+        if check_order['status'] == 'NEW' or check_order['status'] == 'PARTIALLY_FILLED':
             Orders.cancel_order(symbol, orderId)
             with self._lock:
                 self.order_id = 0


### PR DESCRIPTION
Fixes a logic error in the cancel() function at app/Trading.py:413. The condition check_order['status'] == 'NEW' or check_order['status'] \!= 'CANCELLED' was always true for any order status that is not 'CANCELLED', including 'FILLED', 'PARTIALLY_FILLED', 'EXPIRED', etc. This caused the function to attempt canceling orders that were already filled or in other non-cancellable states. Changed to check for specific cancellable statuses ('NEW' and 'PARTIALLY_FILLED') matching the pattern used elsewhere in the code (line 285).